### PR TITLE
Not-really-needed commit to retry CI.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,15 @@
-:: Just delegate to the Unixy script.
-bash %RECIPE_DIR%\build.sh
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,9 @@
 set -e
 IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
 
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
 # Fresh OS-guessing scripts from xorg-util-macros for win64
 for f in config.guess config.sub ; do
     cp -p $PREFIX/share/util-macros/$f .


### PR DESCRIPTION
The first build of this package didn't trigger AppVeyor, and so we don't have
a Windows version of this package. I don't know if a PR will fix that, but
it's worth a try. This commit updates `bld.sh` and `build.sh` based on my
subsequent work on getting X.org to build on Windows. The changes aren't
needed for this simple package, but as long as I'm looking for an excuse to
make a commit, I might as well incorporate them.